### PR TITLE
Fix getPreds

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -53,7 +53,7 @@ function getPreds(hms, center, scale)
     preds[{{}, {}, 1}]:apply(function(x) return (x - 1) % hms:size(4) + 1 end)
     preds[{{}, {}, 2}]:add(-1):div(hms:size(3)):floor():add(1)
     local predMask = max:gt(0):repeatTensor(1, 1, 2):float()
-    preds:add(-.5):cmul(predMask):add(1)
+    preds:add(-1):cmul(predMask):add(1)
 
     -- Get transformed coordinates
     local preds_tf = torch.zeros(preds:size())


### PR DESCRIPTION
In commit https://github.com/anewell/pose-hg-demo/commit/bc04ea1d199263a94869bee994a05383969dd0fe a change was applied, which I believe was in response to issue https://github.com/anewell/pose-hg-demo/issues/7. I have evaluated the pretrained model with and without the change, and have found that the reported validation accuracy is significantly worse *after* that commit was made.

I believe the problematic line of code is:

https://github.com/anewell/pose-hg-demo/blob/bc04ea1d199263a94869bee994a05383969dd0fe/util.lua#L56

If I change the line to match pose-hg-train (https://github.com/anewell/pose-hg-train/blob/f61d3c60c7fe1c9a3292ffcf4266e448f87bbad0/src/util/eval.lua#L37), the problem goes away. This PR contains that change.